### PR TITLE
Fix tests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,21 @@
 # noinspection PyUnresolvedReferences
+import os
 import odoo
-from . import mixins, controllers, models, wizards
+import odoo.tests
+
+from odoo.tools import config as odoo_config
+from odoo.modules.module import initialize_sys_path
+
+env_addons_path = os.environ.get("ODOO_ADDONS_PATH")
+current_addons_path = odoo_config.get("addons_path")
+env_db_name = os.environ.get("ODOO_DATABASE")
+
+if env_db_name and not odoo_config.get("db_name"):
+    odoo_config["db_name"] = env_db_name
+
+if env_addons_path and env_addons_path != current_addons_path:
+    odoo_config["addons_path"] = env_addons_path
+    initialize_sys_path()
+
+if __name__.startswith("odoo.addons."):
+    from . import mixins, controllers, models, wizards

--- a/tests/test_services_shopify_helpers.py
+++ b/tests/test_services_shopify_helpers.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, UTC
 
-from odoo.tests.common import TransactionCase
+from unittest import TestCase
 from ..services.shopify.helpers import (
     parse_shopify_datetime_to_utc,
     format_datetime_for_shopify,
@@ -22,7 +22,7 @@ class DummyImage:
         self.create_date = create_date
 
 
-class TestShopifyHelpers(TransactionCase):
+class TestShopifyHelpers(TestCase):
     def test_parse_and_format_datetime_round_trip(self) -> None:
         original = datetime(2025, 5, 17, 12, 45, 30, tzinfo=UTC)
         formatted = format_datetime_for_shopify(original)


### PR DESCRIPTION
## Summary
- adjust addon init to set addons path and db name when not loaded by Odoo
- use unittest.TestCase in helper tests to avoid requiring Odoo

## Testing
- `pytest --odoo-log-level=warn product_connect/tests/test_services_shopify_helpers.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS="" pytest -q product_connect/tests/test_services_shopify_helpers.py`