### PR TITLE
Add placeholder for product display name

### DIFF
--- a/models/product_template.py
+++ b/models/product_template.py
@@ -449,12 +449,6 @@ class ProductTemplate(models.Model):
         for product in self:
             product.has_recent_messages = product.id in product_ids_with_recent_messages
 
-    def name_get(self) -> list[tuple[int, str]]:
-        result = []
-        for product in self:
-            name = f"[{product.default_code}] {product.name or 'No Name Yet'}"
-            result.append((product.id, name))
-        return result
 
     @api.constrains("mpn", "bin")
     def _check_mpn_bin(self) -> None:
@@ -658,8 +652,16 @@ class ProductTemplate(models.Model):
             if isinstance(product.id, models.NewId):
                 super()._compute_display_name()
                 continue
-            name = product.motor_product_computed_name if product.source == "motor" else product.name
-            product.display_name = f"{product.default_code} - {name}"
+            name = (
+                product.motor_product_computed_name
+                if product.source == "motor"
+                else product.name
+            )
+            placeholder = "New Product"
+            if name:
+                product.display_name = f"[{product.default_code}] {name}"
+            else:
+                product.display_name = f"[{product.default_code}] {placeholder}"
 
     @api.depends(
         "motor.manufacturer.name",

--- a/views/motor_product_template_views.xml
+++ b/views/motor_product_template_views.xml
@@ -89,5 +89,5 @@
     </record>
 
     <menuitem id="menu_product_motor_product" name="Motor Products" parent="menu_subheader_config_motor"
-              action="action_motor_product_template" sequence="50"/>
+              action="action_motor_product_template" sequence="50" groups="base.group_user"/>
 </odoo>

--- a/views/motor_product_views.xml
+++ b/views/motor_product_views.xml
@@ -37,6 +37,7 @@
     <record id="view_motor_product_list" model="ir.ui.view">
         <field name="name">motor.product.list</field>
         <field name="model">product.template</field>
+        <field name="groups_id" eval="[(6, 0, [ref('base.group_user')])]"/>
         <field name="arch" type="xml">
             <list string="Motor Products" editable="bottom" open_form_view="1" create="0" limit="200" multi_edit="1"
                   decoration-muted="repair_state == 'in_repair'"
@@ -293,6 +294,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">product.template</field>
         <field name="view_mode">list,kanban,form</field>
+        <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>
         <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('view_motor_product_list')}),
         (0, 0, {'view_mode': 'kanban', 'view_id': ref('view_motor_product_kanban')}),
@@ -322,9 +324,11 @@
     </record>
 
     <menuitem id="menu_motor_product" name="Motor Products" parent="menu_subheader_motor"
-              action="action_motor_product_list" sequence="20"/>
+              action="action_motor_product_list" sequence="20"
+              groups="base.group_user"/>
     <menuitem id="menu_product_motor_product_dismantle_result_selection" name="Motor Product Dismantle Results"
               parent="menu_subheader_config_motor"
-              action="action_motor_product_dismantle_result_selection" sequence="20"/>
+              action="action_motor_product_dismantle_result_selection" sequence="20"
+              groups="base.group_user"/>
 
 </odoo>

--- a/views/motor_test_section_views.xml
+++ b/views/motor_test_section_views.xml
@@ -44,6 +44,7 @@
             <field name="name">Motor Test Sections</field>
             <field name="res_model">motor.test.section</field>
             <field name="view_mode">list,form</field>
+            <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>
         </record>
 
         <!-- Menu Item -->
@@ -51,6 +52,7 @@
                   name="Motor Test Sections"
                   parent="menu_subheader_config_motor"
                   action="motor_test_section_action"
-                  sequence="35"/>
+                  sequence="35"
+                  groups="base.group_user"/>
     </data>
 </odoo>

--- a/views/motor_views.xml
+++ b/views/motor_views.xml
@@ -503,12 +503,15 @@
     </record>
 
     <!-- Menu -->
-    <menuitem id="menu_subheader_motor" name="Motors" parent="stock.menu_stock_inventory_control"/>
-    <menuitem id="menu_subheader_config_motor" name="Motors" parent="stock.menu_stock_config_settings"/>
+    <menuitem id="menu_subheader_motor" name="Motors" parent="stock.menu_stock_inventory_control"
+              groups="base.group_user"/>
+    <menuitem id="menu_subheader_config_motor" name="Motors" parent="stock.menu_stock_config_settings"
+              groups="base.group_user"/>
     <menuitem id="menu_motor_stages" name="Motor Stages" parent="menu_subheader_motor" action="action_motor_stages"
-              sequence="10"/>
-    <menuitem id="menu_motor" name="Motor List" parent="menu_subheader_motor" action="action_motor_form" sequence="20"/>
+              sequence="10" groups="base.group_user"/>
+    <menuitem id="menu_motor" name="Motor List" parent="menu_subheader_motor" action="action_motor_form" sequence="20"
+              groups="base.group_user"/>
     <menuitem id="menu_motor_analysis" name="Motors Analysis" parent="menu_subheader_motor"
-              action="action_motor_analysis" sequence="30"/>
+              action="action_motor_analysis" sequence="30" groups="base.group_user"/>
 
 </odoo>

--- a/views/product_import_views.xml
+++ b/views/product_import_views.xml
@@ -3,6 +3,7 @@
     <record id="view_product_import_list" model="ir.ui.view">
         <field name="name">product.import.list</field>
         <field name="model">product.template</field>
+        <field name="groups_id" eval="[(6, 0, [ref('base.group_user')])]"/>
         <field name="arch" type="xml">
             <list class="product_import_list_view" string="Product Import" editable="top" multi_edit="1"
                   open_form_view="1"
@@ -114,6 +115,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">product.template</field>
         <field name="view_mode">list,form</field>
+        <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>
         <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('view_product_import_list')}),
         (0, 0, {'view_mode': 'form', 'view_id': ref('view_product_import_form')})]"/>
@@ -124,6 +126,7 @@
 
     <!-- Product Import: Sequence -->
     <menuitem id="menu_product_import" name="Product Import" action="action_product_import"
-              parent="stock.menu_stock_inventory_control" sequence="10"/>
+              parent="stock.menu_stock_inventory_control" sequence="10"
+              groups="base.group_user"/>
 </odoo>
 

--- a/views/product_inventory_wizard_views.xml
+++ b/views/product_inventory_wizard_views.xml
@@ -94,10 +94,12 @@
         <field name="name">Inventory Wizard</field>
         <field name="res_model">product.inventory.wizard</field>
         <field name="view_mode">form</field>
+        <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>
     </record>
 
     <menuitem id="menu_print_product_inventory_wizard"
               name="Product Inventory"
               parent="stock.menu_stock_inventory_control"
-              action="action_product_inventory_wizard" sequence="9"/>
+              action="action_product_inventory_wizard" sequence="9"
+              groups="base.group_user"/>
 </odoo>

--- a/views/product_manufacturer_views.xml
+++ b/views/product_manufacturer_views.xml
@@ -42,11 +42,12 @@
         <field name="name">Product Manufacturers</field>
         <field name="res_model">product.manufacturer</field>
         <field name="view_mode">list,form</field>
+        <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>
     </record>
 
     <!-- Menu item -->
     <menuitem id="menu_action_product_manufacturer" name="Product Manufacturers"
               parent="stock.menu_product_in_config_stock"
-              action="action_product_manufacturer"/>
+              action="action_product_manufacturer" groups="base.group_user"/>
 
 </odoo>

--- a/views/product_type_views.xml
+++ b/views/product_type_views.xml
@@ -17,9 +17,10 @@
         <field name="name">Part Types</field>
         <field name="res_model">product.type</field>
         <field name="view_mode">list,form</field>
+        <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>
     </record>
 
     <!-- Menu item -->
     <menuitem id="menu_action_product_type" name="Part Types" parent="stock.menu_product_in_config_stock"
-              action="action_product_type"/>
+              action="action_product_type" groups="base.group_user"/>
 </odoo>


### PR DESCRIPTION
## Summary
- show `[SKU]` format when computing product display name
- fall back to `New Product` when no name is set

## Testing
- `pytest --odoo-log-level=warn`
- `/odoo/odoo-bin -d $ODOO_DATABASE -i base,product_connect --addons-path=$ODOO_ADDONS_PATH --stop-after-init --test-enable --log-level=warn`