### PR TITLE
Protect test mode from cursor commits

### DIFF
--- a/mixins/notification_manager_mixin.py
+++ b/mixins/notification_manager_mixin.py
@@ -116,7 +116,8 @@ class NotificationManagerMixin(models.AbstractModel):
         shopify_record: BaseModel | None = None,
         error: Exception | None = None,
     ) -> None:
-        self.env.cr.rollback()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.rollback()
         error_traceback = "".join(traceback.format_exception(type(error), error, error.__traceback__)) if error else ""
 
         new_cr = self.env.registry.cursor()

--- a/models/product_template.py
+++ b/models/product_template.py
@@ -539,7 +539,8 @@ class ProductTemplate(models.Model):
                     partner_ids=[self.env.user.partner_id.id],
                 )
 
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
 
     def print_bin_labels(self) -> None:
         unique_bins = [

--- a/models/shopify_sync.py
+++ b/models/shopify_sync.py
@@ -135,14 +135,16 @@ class ShopifySync(models.TransientModel):
                     continue
 
                 vals_to_create.append(vals)
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
 
         if not vals_to_create:
             return self.browse()
 
         syncs = super().create(vals_to_create)
         syncs.state = "queued"
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
         return syncs
 
     def unlink(self) -> models.BaseModel:
@@ -247,7 +249,8 @@ class ShopifySync(models.TransientModel):
                             "start_time": fields.Datetime.now(),
                         }
                     )
-            self.env.cr.commit()
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()
 
             if not next_sync:
                 _logger.debug("No queued syncs found; exiting dispatcher.")
@@ -256,10 +259,12 @@ class ShopifySync(models.TransientModel):
             try:
                 next_sync._execute_mode()
             except (ShopifyApiError, OdooDataError, ShopifySyncRunFailed):
-                self.env.cr.commit()
+                if not self.env.registry.in_test_mode():
+                    self.env.cr.commit()
                 continue
             except Exception:
-                self.env.cr.commit()
+                if not self.env.registry.in_test_mode():
+                    self.env.cr.commit()
                 raise
 
         if self.search([("state", "in", ["running", "queued"])], limit=1):
@@ -311,14 +316,16 @@ class ShopifySync(models.TransientModel):
             vals_list = [vals_list]
 
         sync_jobs = self.create(vals_list)
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
         if sync_jobs:
             sync_jobs.run_async()
         return sync_jobs
 
     def duplicate_and_run_async(self) -> "odoo.model.shopify_sync":
         new_syncs = self.duplicate()
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
         new_syncs.run_async()
         return new_syncs
 
@@ -405,13 +412,15 @@ class ShopifySync(models.TransientModel):
             vals["error_shopify_record"] = _truncate_text(f"{vals.get('error_shopify_record', '')}\n{combined}".strip())
 
         self.write(vals)
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
         _logger.error(f"Shopify sync failed:\n{vals['error_traceback']}")
 
     @contextmanager
     def _run_guard(self) -> Generator[None, None, None]:
         self.write({"state": "running"})
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
         try:
             yield
             self.state = "success"
@@ -419,14 +428,17 @@ class ShopifySync(models.TransientModel):
             if resource_type and self.last_import_start_time:
                 config_key = last_import_config_key(resource_type)
                 self.env["ir.config_parameter"].set_param(config_key, format_datetime_for_shopify(self.last_import_start_time))
-            self.env.cr.commit()
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()
         except Exception as error:
             self._mark_failed(error)
-            self.env.cr.commit()
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()
             raise ShopifySyncRunFailed()
         finally:
             self.end_time = fields.Datetime.now()
-            self.env.cr.commit()
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()
 
     @property
     def completed_str(self) -> str:
@@ -450,7 +462,8 @@ class ShopifySync(models.TransientModel):
         products.shopify_ebay_category_id = False
 
         self.total_count = max(len(products), self.total_count)
-        self.env.cr.commit()
+        if not self.env.registry.in_test_mode():
+            self.env.cr.commit()
 
     def _run_import_all_products(self) -> None:
         _logger.info("Importing all products from Shopify")

--- a/services/shopify/sync/base.py
+++ b/services/shopify/sync/base.py
@@ -47,11 +47,13 @@ class ShopifyBase(ABC, Generic[T]):
 
     def _maybe_commit(self, processed_count: int) -> None:
         if processed_count % self.commit_size == 0:
-            self.env.cr.commit()
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()
             _logger.info(f"Processed {processed_count} records so far.")
         if time.monotonic() - self._last_heartbeat > HEARTBEAT_SECONDS:
             self.sync_record.write({})
-            self.env.cr.commit()
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()
             self._last_heartbeat = time.monotonic()
 
     def _iterate_pages(


### PR DESCRIPTION
## Summary
- guard commit and rollback statements with test-mode checks

## Testing
- `pytest --odoo-log-level=warn`
- `/odoo/odoo-bin --database="$ODOO_DATABASE" --init=base,product_connect --addons-path="$ODOO_ADDONS_PATH" --stop-after-init --test-enable --test-tags=product_connect --log-level=warn`
