### PR TITLE
Refactor tests for shopify helpers

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,17 @@
+import os
+import odoo
+from odoo.tools import config as odoo_config
+from odoo.modules.module import initialize_sys_path
+
+addons_path = os.environ.get("ODOO_ADDONS_PATH")
+current_path = odoo_config.get("addons_path")
+database_name = os.environ.get("ODOO_DATABASE")
+
+if database_name and not odoo_config.get("db_name"):
+    odoo_config["db_name"] = database_name
+
+if addons_path and addons_path != current_path:
+    odoo_config["addons_path"] = addons_path
+    initialize_sys_path()
+
+import odoo.tests

--- a/tests/test_shopify_helpers.py
+++ b/tests/test_shopify_helpers.py
@@ -1,0 +1,98 @@
+from datetime import datetime, UTC
+from dataclasses import dataclass
+from pydantic import BaseModel
+
+import pytest
+
+from ..services.shopify import helpers
+
+
+def test_normalize_str():
+    assert helpers.normalize_str(" TeSt  ") == "test"
+
+
+def test_normalize_phone():
+    assert helpers.normalize_phone("+1 (800) 555-1234") == "18005551234"
+
+
+def test_normalize_email():
+    assert helpers.normalize_email(" Example@Email.Com ") == "example@email.com"
+
+
+@dataclass
+class FakeImage:
+    sequence: int | None = None
+    create_date: datetime | None = None
+
+
+def test_image_order_key():
+    dt = datetime(2024, 1, 1)
+    image = FakeImage(sequence=2, create_date=dt)
+    assert helpers.image_order_key(image) == (2, dt)
+
+
+def test_last_import_config_key():
+    assert helpers.last_import_config_key("product") == "shopify.last_product_import_time"
+
+
+def test_syncmode_properties():
+    mode = helpers.SyncMode.IMPORT_ALL_PRODUCTS
+    assert mode.display_name == "Import All Products"
+    assert mode.resource_type == "product"
+    choices = helpers.SyncMode.choices()
+    assert (mode.value, mode.display_name) in choices
+
+
+@dataclass
+class FakeRecord:
+    name: str = "prod"
+    id: int = 42
+    default_code: str = "SKU"
+
+
+def test_odoo_data_error_str():
+    exc = helpers.OdooDataError("msg", FakeRecord())
+    assert str(exc) == "msg [Odoo Name prod] [Odoo ID 42] [Odoo SKU SKU]"
+
+
+class FakeVariant(BaseModel):
+    sku: str | None = None
+
+
+class FakeShopifyProduct(BaseModel):
+    id: str
+    title: str
+    variants: list[FakeVariant]
+
+
+def test_shopify_api_error_str():
+    product = FakeShopifyProduct(id="gid/123", title="name", variants=[FakeVariant(sku="S1")])
+    exc = helpers.ShopifyApiError("err", shopify_record=product)
+    assert str(exc) == "err [Odoo Name name] [Shopify ID gid/123]"
+
+
+def test_parse_shopify_datetime_to_utc():
+    value = "2024-05-20T12:34:56Z"
+    dt = helpers.parse_shopify_datetime_to_utc(value)
+    assert dt == datetime(2024, 5, 20, 12, 34, 56)
+
+
+def test_format_datetime_for_shopify():
+    dt = datetime(2024, 5, 20, 12, 34, 56, tzinfo=UTC)
+    assert helpers.format_datetime_for_shopify(dt) == "2024-05-20T12:34:56Z"
+
+
+def test_parse_shopify_id_from_gid():
+    assert helpers.parse_shopify_id_from_gid("gid://shopify/Product/123") == "123"
+
+
+def test_format_shopify_gid_from_id():
+    assert helpers.format_shopify_gid_from_id("Product", 123) == "gid://shopify/Product/123"
+
+
+def test_parse_shopify_sku_field_to_sku_and_bin():
+    assert helpers.parse_shopify_sku_field_to_sku_and_bin("SKU1 - Bin") == ("SKU1", "Bin")
+
+
+def test_format_sku_bin_for_shopify():
+    assert helpers.format_sku_bin_for_shopify("SKU1", "Bin") == "SKU1 - Bin"


### PR DESCRIPTION
## Summary
- allow pytest to resolve Odoo modules via a test package initializer
- use a package-relative import for Shopify helper tests

## Testing
- `pytest --odoo-log-level=warn`