### PR TITLE
Fix Shopify sync view XML

### DIFF
--- a/views/shopify_sync_views.xml
+++ b/views/shopify_sync_views.xml
@@ -127,7 +127,7 @@
                             string="Duplicate"
                             type="object"
                             class="btn-primary"
-                            invisible="state in ['draft','queued']"/>"
+                            invisible="state in ['draft','queued']"/>
                 </header>
                 <sheet>
                     <group>
@@ -135,7 +135,7 @@
                         <field name="odoo_products_to_sync" invisible="mode != 'export_batch'"/>
                         <field name="shopify_product_id_to_sync" invisible="'import_one' not in mode"/>
                         <field name="datetime_to_sync" string="Date from"
-                               invisible="'_since' not in mode"/>=
+                               invisible="'_since' not in mode"/>
                         <field name="create_date" readonly="1" String="Create Time"/>
                         <field name="start_time" readonly="1" invisible="not start_time" widget="date"/>
                         <field name="end_time" readonly="1" invisible="not end_time"/>


### PR DESCRIPTION
## Summary
- fix malformed XML syntax in `shopify_sync_views.xml`

## Testing
- `pytest --odoo-log-level=warn` *(fails: Invalid import of product_connect.models.delivery_carrier.DeliveryCarrier)*