### PR TITLE
Fix partner view xpath

### DIFF
--- a/views/product_template_views.xml
+++ b/views/product_template_views.xml
@@ -140,7 +140,6 @@
             </xpath>
         </field>
     </record>
-    prettier-plugin-xml
 
     <record id="product_template_list_edit" model="ir.ui.view">
         <field name="name">product.template.list.edit</field>

--- a/views/res_partner_views.xml
+++ b/views/res_partner_views.xml
@@ -16,23 +16,21 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet" position="inside">
-                <notebook>
-                    <page string="External Integrations">
-                        <group col="2">
-                            <group>
-                                <separator string="Shopify"/>
-                                <field name="shopify_customer_id" widget="CopyClipboardChar"/>
-                                <field name="shopify_customer_admin_url" widget="CopyClipboardURL"/>
-                            </group>
-                            <group>
-                                <separator string="eBay"/>
-                                <field name="ebay_username"/>
-                                <field name="ebay_profile_url" widget="CopyClipboardURL"/>
-                            </group>
+            <xpath expr="//notebook" position="inside">
+                <page string="External Integrations">
+                    <group col="2">
+                        <group>
+                            <separator string="Shopify"/>
+                            <field name="shopify_customer_id" widget="CopyClipboardChar"/>
+                            <field name="shopify_customer_admin_url" widget="CopyClipboardURL"/>
                         </group>
-                    </page>
-                </notebook>
+                        <group>
+                            <separator string="eBay"/>
+                            <field name="ebay_username"/>
+                            <field name="ebay_profile_url" widget="CopyClipboardURL"/>
+                        </group>
+                    </group>
+                </page>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- adjust XML template to insert page inside existing notebook
- remove leftover Prettier markup that broke product templates

## Testing
- `pytest --odoo-log-level=warn`
- `/odoo/odoo-bin --database=$ODOO_DATABASE --init=base,product_connect --addons-path=$ODOO_ADDONS_PATH --stop-after-init --test-enable --log-level=warn`
