### PR TITLE
Restrict standard price columns

### DIFF
--- a/views/motor_product_views.xml
+++ b/views/motor_product_views.xml
@@ -39,7 +39,7 @@
         <field name="model">product.template</field>
         <field name="groups_id" eval="[(6, 0, [ref('base.group_user')])]"/>
         <field name="arch" type="xml">
-            <list string="Motor Products" editable="bottom" open_form_view="1" create="0" limit="200" multi_edit="1"
+            <list string="Motor Products" groups="base.group_user" editable="bottom" open_form_view="1" create="0" limit="200" multi_edit="1"
                   decoration-muted="repair_state == 'in_repair'"
                   decoration-warning="(not name or not list_price or list_price == 0 or not standard_price or standard_price == 0) and repair_state != 'in_repair'"
                   decoration-danger="has_recent_messages"

--- a/views/product_import_views.xml
+++ b/views/product_import_views.xml
@@ -5,7 +5,7 @@
         <field name="model">product.template</field>
         <field name="groups_id" eval="[(6, 0, [ref('base.group_user')])]"/>
         <field name="arch" type="xml">
-            <list class="product_import_list_view" string="Product Import" editable="top" multi_edit="1"
+            <list class="product_import_list_view" groups="base.group_user" string="Product Import" editable="top" multi_edit="1"
                   open_form_view="1"
                   decoration-warning="not name or not list_price or list_price == 0 or not standard_price or standard_price == 0"
                   decoration-danger="has_recent_messages">


### PR DESCRIPTION
## Summary
- restrict motor product list view to base users
- restrict product import list view to base users

## Testing
- `pytest --odoo-log-level=warn`
- `odoo-bin --database=$ODOO_DATABASE --addons-path=$ODOO_ADDONS_PATH --update=product_connect --stop-after-init --log-level=warn` *(fails: Invalid attribute groups for element list)*