### PR TITLE
Add unit tests for ShopifyService

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_shopify_helpers
+from . import test_shopify_helpers, test_shopify_service

--- a/tests/test_shopify_helpers.py
+++ b/tests/test_shopify_helpers.py
@@ -4,11 +4,12 @@ from typing import Any, Callable, List, Tuple, cast
 from pydantic import BaseModel
 
 from odoo.exceptions import UserError
-from odoo.tests import BaseCase
+from odoo.tests import TransactionCase
 from ..services.shopify import helpers
 
 
-class TestShopifyHelpers(BaseCase):
+class TestShopifyHelpers(TransactionCase):
+    test_tags = {"-at_install", "-post_install"}
     def test_normalise_values(self) -> None:
         cases: List[Tuple[str, Callable[[str], str], str]] = [
             (" TeSt  ", helpers.normalize_str, "test"),

--- a/tests/test_shopify_service.py
+++ b/tests/test_shopify_service.py
@@ -1,0 +1,56 @@
+from typing import Any
+from odoo.tests import TransactionCase
+from ..services.shopify.service import ShopifyService
+
+
+class DummySync:
+    def __init__(self) -> None:
+        self.id = 1
+        self.hard_throttle_count = 0
+
+
+class TestShopifyService(TransactionCase):
+    test_tags = {"-at_install", "-post_install"}
+    def _service(self) -> ShopifyService:
+        return ShopifyService(self.env, DummySync())
+
+    def test_compute_throttle_delay_none(self) -> None:
+        service = self._service()
+        self.assertIsNone(service._compute_throttle_delay({}))
+
+    def test_compute_throttle_delay_zero(self) -> None:
+        service = self._service()
+        data = {
+            "extensions": {"cost": {"throttleStatus": {"currentlyAvailable": service.MIN_API_POINTS}}}
+        }
+        self.assertEqual(service._compute_throttle_delay(data), 0.0)
+
+    def test_compute_throttle_delay_bounds(self) -> None:
+        service = self._service()
+        data = {
+            "extensions": {"cost": {"throttleStatus": {"currentlyAvailable": 100, "restoreRate": 25}}}
+        }
+        self.assertEqual(service._compute_throttle_delay(data), 16.0)
+        data = {
+            "extensions": {"cost": {"throttleStatus": {"currentlyAvailable": 0, "restoreRate": 0}}}
+        }
+        self.assertEqual(service._compute_throttle_delay(data), 60.0)
+        data = {
+            "extensions": {"cost": {"throttleStatus": {"currentlyAvailable": service.MIN_API_POINTS - 1, "restoreRate": 1000}}}
+        }
+        self.assertEqual(service._compute_throttle_delay(data), 1.0)
+
+    def test_throttle_info_with_error(self) -> None:
+        service = self._service()
+        data = {
+            "errors": [{"extensions": {"code": "THROTTLED"}}],
+            "extensions": {"cost": {"throttleStatus": {"currentlyAvailable": 400, "restoreRate": 10}}},
+        }
+        self.assertEqual(service._throttle_info(data), (True, 10.0))
+
+    def test_throttle_info_without_error(self) -> None:
+        service = self._service()
+        data = {
+            "extensions": {"cost": {"throttleStatus": {"currentlyAvailable": 499, "restoreRate": 1000}}}
+        }
+        self.assertEqual(service._throttle_info(data), (False, 1.0))


### PR DESCRIPTION
## Summary
- add tests for ShopifyService throttle helpers
- register new test module
- adjust helper tests to use TransactionCase

## Testing
- `pytest -q --odoo-database=odoo-test`