### PR TITLE
Improve service tests

### DIFF
--- a/services/tests/test_shopify_helpers.py
+++ b/services/tests/test_shopify_helpers.py
@@ -171,3 +171,52 @@ class TestShopifyHelpers(TransactionCase):
 
         t1, t2, t3 = datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 3)
         self.assertEqual(helpers.determine_latest_odoo_product_modification_time(Prod(t1, t2, t3)), t3)
+
+    def test_parse_datetime_and_gid_and_sku_errors(self) -> None:
+        naive_dt = datetime(2024, 5, 20, 12, 34, 56)
+        self.assertEqual(helpers.parse_shopify_datetime_to_utc(naive_dt), naive_dt)
+        self.assertEqual(helpers.parse_shopify_id_from_gid(5), "5")
+        self.assertEqual(helpers.format_shopify_gid_from_id("product", 5), "gid://shopify/product/5")
+        with self.assertRaises(helpers.ShopifyMissingSkuFieldError):
+            helpers.parse_shopify_sku_field_to_sku_and_bin(" ")
+        with self.assertRaises(helpers.OdooMissingSkuError):
+            helpers.format_sku_bin_for_shopify("", "bin")
+
+    def test_write_if_changed_multirecord_and_api_error_cause(self) -> None:
+        class Base:
+            pass
+
+        helpers.models.BaseModel = Base  # type: ignore
+
+        class Multi(Base):
+            def __len__(self) -> int:
+                return 2
+
+            id = 1
+
+        class Rec:
+            def __init__(self) -> None:
+                self.field = Multi()
+                self._fields = {"field": object()}
+
+            def __getitem__(self, name: str) -> Any:
+                return getattr(self, name)
+
+        with self.assertRaises(UserError):
+            helpers.write_if_changed(cast(Any, Rec()), {"field": Multi()})
+
+        class Var(BaseModel):
+            sku: str | None = None
+
+        class Vars(BaseModel):
+            nodes: list[Var]
+
+        class Prod(BaseModel):
+            id: str
+            title: str
+            variants: Vars
+
+        prod = Prod(id="gid/1", title="n", variants=Vars(nodes=[Var()]))
+        err = helpers.ShopifyApiError("msg", shopify_record=prod)
+        err.__cause__ = ValueError("boom")
+        self.assertIn("Shopify error: boom", str(err))

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -1,4 +1,9 @@
+from typing import Callable
+from unittest.mock import patch
+
+from httpx import Request, Response
 from odoo.tests import TransactionCase
+
 from ..shopify.service import ShopifyService
 
 
@@ -46,3 +51,70 @@ class TestShopifyService(TransactionCase):
         service = self._service()
         data = {"extensions": {"cost": {"throttleStatus": {"currentlyAvailable": 499, "restoreRate": 1000}}}}
         self.assertEqual(service._throttle_info(data), (False, 1.0))
+
+    def test_get_first_location_gid(self) -> None:
+        service = self._service()
+
+        class Loc:
+            def __init__(self, gid: str) -> None:
+                self.id = gid
+
+        class Response:
+            def __init__(self, nodes: list[Loc]) -> None:
+                self.nodes = nodes
+
+        service._client = type("Client", (), {"get_locations": lambda self: Response([Loc("gid1")])})()
+        self.assertEqual(service.get_first_location_gid(), "gid1")
+
+    def test_get_first_location_gid_error(self) -> None:
+        service = self._service()
+        service._client = type("Client", (), {"get_locations": lambda self: type("Res", (), {"nodes": []})()})()
+        with self.assertRaises(Exception):
+            service.get_first_location_gid()
+
+    def test_create_client_success_and_retry(self) -> None:
+        config = self.env["ir.config_parameter"].sudo()
+        config.set_param("shopify.shop_url_key", "shop")
+        config.set_param("shopify.api_token", "token")
+        service = self._service()
+
+        class DummyClient:
+            def __init__(self, **_kw: object) -> None:
+                self.event_hooks: dict[str, list[Callable[[Response], None]]] = {}
+                self.send_calls: list[Request] = []
+                self.send_func: Callable[[Request], Response] = lambda request: Response(200, request=request, json={})
+
+            def send(self, request: Request, **_kw: object) -> Response:
+                self.send_calls.append(request)
+                return self.send_func(request)
+
+        req = Request("GET", "http://t")
+        responses = [Response(200, request=req, json={}), Response(200, request=req, json={})]
+
+        def send_one(_request: Request) -> Response:
+            return responses.pop(0)
+
+        with patch("product_connect.services.shopify.service.Client", DummyClient), patch(
+            "product_connect.services.shopify.service.ShopifyClient", (lambda http_client, url: http_client)
+        ), patch("product_connect.services.shopify.service.sleep") as fake_sleep, patch.object(
+            service, "get_first_location_gid", return_value="loc"
+        ), patch.object(
+            service,
+            "_throttle_info",
+            side_effect=[(True, None), (False, None)],
+        ):
+            client = service._create_client()
+            self.assertIs(service._client, client)
+            client.send_func = send_one
+            result = client.send(req)
+            self.assertEqual(result.status_code, 200)
+            self.assertEqual(len(client.send_calls), 2)
+            fake_sleep.assert_called_with(1.0)
+            self.assertEqual(service.sync_record.hard_throttle_count, 1)
+
+    def test_create_client_missing_credentials(self) -> None:
+        config = self.env["ir.config_parameter"].sudo()
+        config.set_param("shopify.shop_url_key", "")
+        service = self._service()
+        with self.assertRaises(Exception):
+            service._create_client()


### PR DESCRIPTION
## Summary
- extend Shopify service tests for HTTP client logic and credential errors
- cover additional edge cases in Shopify helper utilities

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `pytest --odoo-log-level=warn --cov=product_connect/services --cov-report=term-missing`