### PR TITLE
Add instructions for serial and model location

### DIFF
--- a/guides/motor_checkin_guide.md
+++ b/guides/motor_checkin_guide.md
@@ -1,0 +1,42 @@
+# Motor Check-In Guide
+
+This guide explains how technicians should use the Motor module in Odoo for recording and checking in motors.
+
+## Opening the Motor List
+1. From the main Odoo dashboard, select **Inventory → Motors → Motor List**.
+2. Browse existing motors in the list or click **Create** to start a new record.
+
+## Creating a Motor
+1. After clicking **Create**, you will be on the **Basic Info** tab.
+2. Fill in all relevant details such as manufacturer, horsepower, stroke, configuration, model, sub-model, serial number, year, color, cost, vendor, and lot. Add any notes in the provided field.
+3. The stage defaults to **Checkin** when you create a motor. Save the form to generate the motor number automatically.
+
+## Locating the Serial and Model Numbers
+1. Remove or lift the engine cover to find the identification plate or sticker.
+2. The plate is usually near the mounting bracket or on the upper portion of the engine block.
+3. Record the values labeled **Model** and **Serial** for entry in the form.
+4. If the plate is missing or unreadable, check any paperwork that came with the motor.
+
+## Adding Images
+- Use the **Images** tab to upload photos of the motor. Standard image placeholders are provided for consistency.
+- Click **Download Images** at the top to download all photos if needed.
+
+## Marking Missing Parts
+1. Go to the **Missing Parts** tab.
+2. Toggle the switch next to each part name to indicate missing items.
+3. Enter additional notes in the text box below the list if required.
+
+## Running Motor Tests
+- The **Basic Testing** and **Extended Testing** tabs contain various tests.
+- Enter values or upload files directly within each test line. Data is saved automatically.
+
+## Compression Test
+- If applicable, the **Compression** tab lists cylinders with PSI entry fields.
+- Mark a cylinder as **Untestable** when compression data cannot be gathered. Use **Mark All Untestable** if necessary.
+
+## Finalizing Check‑In
+1. Review the **Summary** tab to see a read‑only view of all details and test results.
+2. Change the stage to the appropriate next step (such as **Done**) using the status bar at the top.
+3. Use **Print Motor Label** from the **Basic Info** tab if labels are required.
+
+Following these steps allows a technician to fully document a motor and complete its check‑in.


### PR DESCRIPTION
## Summary
- update the motor check-in guide with instructions on how to locate the motor's serial and model numbers

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' product_connect`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' product_connect`
- `pytest --odoo-log-level=warn` *(fails to import Odoo test framework)*