### PR TITLE
Fix product sync FK error

### DIFF
--- a/models/product_template.py
+++ b/models/product_template.py
@@ -176,8 +176,9 @@ class ProductTemplate(models.Model):
             return products
 
         if consumable_products := products.filtered(lambda p: p.type == "consu"):
+            variant_ids = consumable_products.mapped("product_variant_ids").ids
             self.env["shopify.sync"].create_and_run_async(
-                {"mode": SyncMode.EXPORT_BATCH_PRODUCTS, "odoo_products_to_sync": [(6, 0, consumable_products.ids)]}
+                {"mode": SyncMode.EXPORT_BATCH_PRODUCTS, "odoo_products_to_sync": [(6, 0, variant_ids)]}
             )
 
         return products

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -96,9 +96,9 @@ class TestShopifyService(TransactionCase):
         def send_one(_request: Request) -> Response:
             return responses.pop(0)
 
-        with patch.object(_service_module.httpx, "Client", DummyClient), patch.object(
+        with patch.object(_service_module, "Client", DummyClient), patch.object(
             _service_module, "ShopifyClient", lambda http_client, url: http_client
-        ), patch.object(_service_module, _service_module.sleep.__name__) as fake_sleep, patch.object(
+        ), patch.object(_service_module, "sleep") as fake_sleep, patch.object(
             service, "get_first_location_gid", return_value="loc"
         ), patch.object(
             service, "_throttle_info", side_effect=[(True, None), (False, None)]

--- a/tests/test_product_template.py
+++ b/tests/test_product_template.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from odoo.tests import TransactionCase
+from odoo.addons.product_connect.services.shopify.helpers import SyncMode
+
+
+class TestProductTemplate(TransactionCase):
+    test_tags = {"-at_install", "-post_install"}
+
+    def test_create_syncs_variants(self) -> None:
+        with patch.object(type(self.env["shopify.sync"]), "create_and_run_async") as create_sync:
+            product = self.env["product.template"].create({"name": "Test", "type": "consu"})
+            variant_ids = product.product_variant_ids.ids
+            create_sync.assert_any_call({"mode": SyncMode.EXPORT_BATCH_PRODUCTS, "odoo_products_to_sync": [(6, 0, variant_ids)]})


### PR DESCRIPTION
## Summary
- reference product variant IDs when queuing product syncs
- adjust test patch targets to use module objects
- add test covering product variant sync creation

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `pytest --odoo-log-level=warn`