### PR TITLE
Fix image mixin compute

### DIFF
--- a/mixins/image_mixin.py
+++ b/mixins/image_mixin.py
@@ -70,10 +70,12 @@ class ImageMixin(models.AbstractModel):
         for record in self:
             db_name = self.env.cr.dbname
             filestore_path = Path(config.filestore(db_name))
-            if not record.attachment.store_fname:
+            attachment: "odoo.model.ir_attachment" = record.attachment
+            store_fname = attachment.store_fname
+            if not store_fname:
                 self._reset_image_details(record)
                 continue
-            image_path = filestore_path / Path(record.attachment.store_fname)
+            image_path = filestore_path / Path(store_fname)
 
             try:
                 with Image.open(image_path) as img:


### PR DESCRIPTION
## Summary
- use typed attachment record when computing image dimensions

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `pytest --odoo-log-level=warn`