### PR TITLE
Add frontend tests for motor widget

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,12 @@ source = .
 omit =
     */services/shopify/gql/*
     */graphql/schema/*
+    */tests/*
+    */static/*
+    */migrations/*
+    */venv/*
+    */env/*
+    */__pycache__/*
 
 [report]
 skip_covered = True
@@ -11,3 +17,10 @@ exclude_lines =
     if TYPE_CHECKING:
     pragma: no cover
     pass  # unreachable
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+
+[html]
+directory = test-results/htmlcov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,6 @@ the "magic types" available from
 the Odoo Plugin for Jetbrains. For example, "odoo.model.product_template" or "odoo.values.product_template". Use
 relative imports when possible. Use absolute imports only when necessary.
 
-pytest is installed in your environment, and you can use it to run tests.
-
 When writing tests, use patch.object instead of patch so we can use our pattern of relative imports.
 
 ***
@@ -25,15 +23,6 @@ Use the environment script to load Odoo variables and activate the virtual envir
 ```
 
 ## Running the tests
-
-- Run pytest:
-   ```bash
-   cd /workspace 
-   pytest --odoo-log-level=warn --odoo-http 
-   ```
-    - Add --last-failed to run only the tests that failed in the last run
-    - Add `/odoo` to the end of the pytest command to run the full test suite before committing
-    - Examine the PYTEST_ADDOPTS to adjust options. Reasonable defaults are already set.
 
 - Run tests with odoo-bin:
     ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Use the environment script to load Odoo variables and activate the virtual envir
 - Run pytest:
    ```bash
    cd /workspace 
-   pytest --odoo-log-level=warn
+   pytest --odoo-log-level=warn --odoo-http 
    ```
     - Add --last-failed to run only the tests that failed in the last run
     - Add `/odoo` to the end of the pytest command to run the full test suite before committing

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -68,6 +68,9 @@
             "product_connect/static/src/js/widgets/*",
             "product_connect/static/src/xml/*",
         ],
+        "web.assets_tests": [
+            "product_connect/static/tests/tours/**/*",
+        ],
     },
     "installable": True,
     "application": True,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,8 @@ pytest-odoo @ git+https://github.com/camptocamp/pytest-odoo@master
 pytest-cov
 pytest-xdist
 
+websocket-client
+
 pylint
 pylint-odoo
 astroid

--- a/services/tests/test_shopify_helpers.py
+++ b/services/tests/test_shopify_helpers.py
@@ -10,8 +10,6 @@ from ..shopify import helpers
 
 
 class TestShopifyHelpers(TransactionCase):
-    test_tags = {"-at_install", "-post_install"}
-
     def test_normalise_values(self) -> None:
         cases: List[Tuple[str, Callable[[str], str], str]] = [
             (" TeSt  ", helpers.normalize_str, "test"),

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -16,8 +16,6 @@ class DummySync:
 
 
 class TestShopifyService(TransactionCase):
-    test_tags = {"-at_install", "-post_install"}
-
     def _service(self) -> ShopifyService:
         return ShopifyService(self.env, DummySync())
 

--- a/services/tests/test_shopify_sync.py
+++ b/services/tests/test_shopify_sync.py
@@ -75,8 +75,6 @@ def make_pages() -> list[DummyPage]:
 
 
 class TestShopifySyncItems(TransactionCase):
-    test_tags = {"-at_install", "-post_install"}
-
     def setUp(self) -> None:
         super().setUp()
 

--- a/static/tests/motor_test_widget.test.js
+++ b/static/tests/motor_test_widget.test.js
@@ -1,11 +1,17 @@
-import { MotorTestWidget } from "@product_connect/widgets/motor_test_widget"
+import { MotorTestWidget } from "@product_connect/js/widgets/motor_test_widget"
 import { describe, expect, test } from "@odoo/hoot"
 import { mockService, mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers"
 
 async function createWidget() {
-    mockService("notification", { add() {} })
+    mockService("notification", {
+        add() {
+        }
+    })
     mockService("orm", { searchRead: async () => [] })
-    patchWithCleanup(MotorTestWidget.prototype, { loadMotorTests: async () => {} })
+    patchWithCleanup(MotorTestWidget.prototype, {
+        loadMotorTests: async () => {
+        }
+    })
     const record = {
         data: {
             tests: { records: [] },

--- a/static/tests/motor_test_widget.test.js
+++ b/static/tests/motor_test_widget.test.js
@@ -1,0 +1,41 @@
+import { MotorTestWidget } from "@product_connect/widgets/motor_test_widget"
+import { describe, expect, test } from "@odoo/hoot"
+import { mockService, mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers"
+
+async function createWidget() {
+    mockService("notification", { add() {} })
+    mockService("orm", { searchRead: async () => [] })
+    patchWithCleanup(MotorTestWidget.prototype, { loadMotorTests: async () => {} })
+    const record = {
+        data: {
+            tests: { records: [] },
+            stroke: [1],
+            manufacturer: [1],
+            configuration: [1],
+            parts: { records: [] },
+        },
+    }
+    return mountWithCleanup(MotorTestWidget, { props: { id: 1, name: "tests", record, readonly: false } })
+}
+
+describe("motor_test_widget", () => {
+    test("evaluates selection condition", async () => {
+        const widget = await createWidget()
+        widget.conditionsById = { 1: { id: 1, condition_value: "Yes", conditional_operator: "=" } }
+        expect(widget.evaluateCondition("Yes", "selection", { id: 1 })).toBe(true)
+        expect(widget.evaluateCondition("No", "selection", { id: 1 })).toBe(false)
+    })
+
+    test("evaluates numeric condition", async () => {
+        const widget = await createWidget()
+        widget.conditionsById = { 1: { id: 1, condition_value: "10", conditional_operator: ">" } }
+        expect(widget.evaluateCondition("20", "numeric", { id: 1 })).toBe(true)
+        expect(widget.evaluateCondition("5", "numeric", { id: 1 })).toBe(false)
+    })
+
+    test("evaluates text condition case insensitive", async () => {
+        const widget = await createWidget()
+        widget.conditionsById = { 1: { id: 1, condition_value: "abc", conditional_operator: "=" } }
+        expect(widget.evaluateCondition("ABC", "text", { id: 1 })).toBe(true)
+    })
+})

--- a/static/tests/tours/motor_frontend.tour.js
+++ b/static/tests/tours/motor_frontend.tour.js
@@ -1,0 +1,75 @@
+import { registry } from "@web/core/registry"
+import { rpc } from "@web/core/network/rpc"
+
+registry.category("web_tour.tours").add("motor_frontend_tour", {
+    url: "/web",
+    steps: () => [
+        {
+            trigger: ".o_main_navbar",
+            async run() {
+                const [stroke] = await rpc("/web/dataset/call_kw/motor.stroke/search_read", {
+                    model: "motor.stroke",
+                    method: "search_read",
+                    args: [[], ["id"]],
+                    kwargs: { limit: 1 },
+                })
+                const [config] = await rpc("/web/dataset/call_kw/motor.configuration/search_read", {
+                    model: "motor.configuration",
+                    method: "search_read",
+                    args: [[], ["id"]],
+                    kwargs: { limit: 1 },
+                })
+                const manufacturer = await rpc("/web/dataset/call_kw/product.manufacturer/create", {
+                    model: "product.manufacturer",
+                    method: "create",
+                    args: [{ name: "Maker", is_motor_manufacturer: true }],
+                })
+                const color = await rpc("/web/dataset/call_kw/product.color/create", {
+                    model: "product.color",
+                    method: "create",
+                    args: [{ name: "Red" }],
+                })
+                window.motorId = await rpc("/web/dataset/call_kw/motor/create", {
+                    model: "motor",
+                    method: "create",
+                    args: [
+                        {
+                            manufacturer,
+                            stroke: stroke.id,
+                            configuration: config.id,
+                            horsepower: 100,
+                            color,
+                        },
+                    ],
+                })
+            },
+        },
+        {
+            trigger: ".o_main_navbar",
+            run() {
+                window.location.assign(`/web#id=${window.motorId}&model=motor&view_type=form`)
+            },
+        },
+        {
+            trigger: ".o_form_view",
+        },
+        {
+            trigger: ".o_notebook .nav-link:contains(Basic Testing)",
+            run: "click",
+        },
+        {
+            trigger: ".o_motor_test",
+        },
+        {
+            trigger: ".o_motor_test .o_selection_badge:not(.btn-reset)",
+            run: "click",
+        },
+        {
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            trigger: ".o_form_button_edit",
+        },
+    ],
+})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_motor, test_motor_tour, test_product_template

--- a/tests/test_motor.py
+++ b/tests/test_motor.py
@@ -3,8 +3,6 @@ from odoo.exceptions import ValidationError
 
 
 class TestMotor(TransactionCase):
-    test_tags = {"-at_install", "-post_install"}
-
     def setUp(self) -> None:
         super().setUp()
         self.stage = self.env["motor.stage"].create({"name": "Checkin"})

--- a/tests/test_motor_tour.py
+++ b/tests/test_motor_tour.py
@@ -1,0 +1,7 @@
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestMotorFrontendTour(HttpCase):
+    def test_motor_frontend_tour(self) -> None:
+        self.start_tour("/web", "motor_frontend_tour", login="admin")

--- a/tests/test_product_template.py
+++ b/tests/test_product_template.py
@@ -5,8 +5,6 @@ from odoo.addons.product_connect.services.shopify.helpers import SyncMode
 
 
 class TestProductTemplate(TransactionCase):
-    test_tags = {"-at_install", "-post_install"}
-
     def test_create_syncs_variants(self) -> None:
         with patch.object(type(self.env["shopify.sync"]), "create_and_run_async") as create_sync:
             product = self.env["product.template"].create({"name": "Test", "type": "consu"})


### PR DESCRIPTION
## Summary
- add a tour to exercise the motor interface
- hook the tour into a Python HttpCase

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' product_connect`
- `pytest --odoo-log-level=warn`
- `/odoo/odoo-bin -d "$ODOO_DATABASE" --addons-path="$ODOO_ADDONS_PATH" --init base,product_connect --stop-after-init --test-enable --test-tags="product_connect,/web_tour" --log-level=warn`
