### PR TITLE
Add Google Chrome for tour tests

### DIFF
--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -15,6 +15,10 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
+# install google chrome repository for tour tests
+wget -qO - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor >/usr/share/keyrings/google-chrome.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+
 apt-get update -qq && \
 apt-get install -y --no-install-recommends \
   build-essential git wget curl ca-certificates gnupg dirmngr \
@@ -23,7 +27,8 @@ apt-get install -y --no-install-recommends \
   libxrender1 libxtst6 xfonts-75dpi xfonts-base libssl-dev \
   python3.12 python3.12-venv python3.12-dev python3.12-full \
   libx11-6 libxcb1 libxext6 gettext libcairo2-dev libcairo2 \
-  chromium chromium-driver xvfb  && \
+  libnss3 libxss1 libasound2 libatk-bridge2.0-0 libgbm1 fonts-liberation \
+  chromium chromium-driver google-chrome-stable xvfb  && \
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 tmp_deb=$(mktemp --suffix=.deb)

--- a/services/tests/test_product_exporter.py
+++ b/services/tests/test_product_exporter.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from odoo.tests import TransactionCase
+from odoo import fields
 
 from ..shopify.sync.exporters.product_exporter import ProductExporter
 from ..shopify import service as _service_module
@@ -51,3 +52,26 @@ class TestProductExporter(TransactionCase):
         self.exporter.service._client = MagicMock()
         self.exporter._publish_product("gid")
         self.exporter.service.client.update_publications.assert_called_once()
+
+    def test_publish_product_skipped_on_test_store(self) -> None:
+        self.env["ir.config_parameter"].sudo().set_param("shopify.test_store", "1")
+        self.exporter.service._client = MagicMock()
+        self.exporter._publish_product("gid")
+        self.exporter.service.client.update_publications.assert_not_called()
+
+    def test_find_products_to_export(self) -> None:
+        tmpl1 = self.env["product.template"].create({"name": "P1", "type": "consu", "website_description": "d"})
+        prod1 = tmpl1.product_variant_id
+        prod1.shopify_next_export = True
+
+        tmpl2 = self.env["product.template"].create({"name": "P2", "type": "consu", "sale_ok": False, "website_description": "d"})
+        prod2 = tmpl2.product_variant_id
+
+        tmpl3 = self.env["product.template"].create({"name": "P3", "type": "consu", "website_description": "d"})
+        prod3 = tmpl3.product_variant_id
+        prod3.shopify_last_exported_at = fields.Datetime.now()
+
+        result = self.exporter._find_products_to_export()
+        self.assertIn(prod1, result)
+        self.assertNotIn(prod2, result)
+        self.assertNotIn(prod3, result)


### PR DESCRIPTION
## Summary
- add Google Chrome repository and dependencies

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `/odoo/odoo-bin -d $ODOO_DATABASE --addons-path=$ODOO_ADDONS_PATH --init product_connect --stop-after-init --test-enable --test-tags="/product_connect" --log-level=warn`
- `/odoo/odoo-bin -d $ODOO_DATABASE --addons-path=$ODOO_ADDONS_PATH --init base,product_connect --stop-after-init --test-enable --test-tags="/web_tour,/web" --log-level=warn`
