### PR TITLE
Add tagging for service tests

### DIFF
--- a/services/tests/test_product_deleter.py
+++ b/services/tests/test_product_deleter.py
@@ -1,7 +1,7 @@
 from httpx import HTTPError
 from unittest.mock import MagicMock, patch
 
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 from ..shopify.sync.deleters.product_deleter import ProductDeleter
 from ..shopify import service as _service_module
@@ -16,6 +16,7 @@ class DummySync:
         self.updated_count = 0
 
 
+@tagged("post_install", "-at_install")
 class TestProductDeleter(TransactionCase):
     def setUp(self) -> None:
         super().setUp()
@@ -63,5 +64,5 @@ class TestProductDeleter(TransactionCase):
             patch.object(ProductDeleter, ProductDeleter.run.__name__) as run,
         ):
             self.deleter.delete_all_products()
-            collect.assert_called_once_with(self.deleter, self.deleter._fetch_product_ids_page)
-            run.assert_called_once_with(self.deleter, collect.return_value)
+            collect.assert_called_once_with(self.deleter._fetch_product_ids_page)
+            run.assert_called_once_with(collect.return_value)

--- a/services/tests/test_product_exporter.py
+++ b/services/tests/test_product_exporter.py
@@ -1,10 +1,11 @@
 from unittest.mock import MagicMock
 
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 from odoo import fields
+from datetime import timedelta
 
 from ..shopify.sync.exporters.product_exporter import ProductExporter
-from ..shopify import service as _service_module
+from ..shopify import helpers as _helpers_module
 
 
 class DummySync:
@@ -18,8 +19,10 @@ class DummySync:
 class DummyPublication:
     def __init__(self, gid: str) -> None:
         self.id = gid
+        self.publication = type("P", (), {"id": gid})()
 
 
+@tagged("post_install", "-at_install")
 class TestProductExporter(TransactionCase):
     def setUp(self) -> None:
         super().setUp()
@@ -34,14 +37,14 @@ class TestProductExporter(TransactionCase):
         self.assertEqual(str(result.id), "gid://shopify/Metafield/5")
 
     def test_is_published_on_channel(self) -> None:
-        gid = "gid://shopify/Publication/" + str(next(iter(_service_module.PUBLICATION_CHANNELS.values())))
+        gid = "gid://shopify/Publication/" + str(next(iter(_helpers_module.PUBLICATION_CHANNELS.values())))
         publication = DummyPublication(gid)
         self.assertTrue(ProductExporter.is_published_on_channel(publication))
         publication.id = "gid://shopify/Publication/999"
         self.assertFalse(ProductExporter.is_published_on_channel(publication))
 
     def test_is_published_on_all_channels(self) -> None:
-        values = list(_service_module.PUBLICATION_CHANNELS.values())
+        values = list(_helpers_module.PUBLICATION_CHANNELS.values())
         channels = [DummyPublication(f"gid://shopify/Publication/{v}") for v in values]
         self.assertTrue(self.exporter.is_published_on_all_channels(channels))
         channels.append(DummyPublication("gid://shopify/Publication/999"))
@@ -60,16 +63,28 @@ class TestProductExporter(TransactionCase):
         self.exporter.service.client.update_publications.assert_not_called()
 
     def test_find_products_to_export(self) -> None:
-        tmpl1 = self.env["product.template"].create({"name": "P1", "type": "consu", "website_description": "d"})
+        tmpl1 = (
+            self.env["product.template"]
+            .with_context(skip_shopify_sync=True)
+            .create({"name": "P1", "type": "consu", "website_description": "d"})
+        )
         prod1 = tmpl1.product_variant_id
         prod1.shopify_next_export = True
 
-        tmpl2 = self.env["product.template"].create({"name": "P2", "type": "consu", "sale_ok": False, "website_description": "d"})
+        tmpl2 = (
+            self.env["product.template"]
+            .with_context(skip_shopify_sync=True)
+            .create({"name": "P2", "type": "consu", "sale_ok": False, "website_description": "d"})
+        )
         prod2 = tmpl2.product_variant_id
 
-        tmpl3 = self.env["product.template"].create({"name": "P3", "type": "consu", "website_description": "d"})
+        tmpl3 = (
+            self.env["product.template"]
+            .with_context(skip_shopify_sync=True)
+            .create({"name": "P3", "type": "consu", "website_description": "d"})
+        )
         prod3 = tmpl3.product_variant_id
-        prod3.shopify_last_exported_at = fields.Datetime.now()
+        prod3.shopify_last_exported_at = fields.Datetime.now() + timedelta(days=1)
 
         result = self.exporter._find_products_to_export()
         self.assertIn(prod1, result)

--- a/services/tests/test_shopify_helpers.py
+++ b/services/tests/test_shopify_helpers.py
@@ -5,10 +5,11 @@ from unittest.mock import patch
 from pydantic import BaseModel
 
 from odoo.exceptions import UserError
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 from ..shopify import helpers
 
 
+@tagged("post_install", "-at_install")
 class TestShopifyHelpers(TransactionCase):
     def test_normalise_values(self) -> None:
         cases: List[Tuple[str, Callable[[str], str], str]] = [

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -2,7 +2,7 @@ from typing import Callable, cast
 from unittest.mock import patch
 
 from httpx import Request, Response
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 
 from ..shopify.service import ShopifyService
@@ -15,6 +15,7 @@ class DummySync:
         self.hard_throttle_count = 0
 
 
+@tagged("post_install", "-at_install")
 class TestShopifyService(TransactionCase):
     def _service(self) -> ShopifyService:
         return ShopifyService(self.env, DummySync())

--- a/services/tests/test_shopify_sync.py
+++ b/services/tests/test_shopify_sync.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from odoo.api import Environment
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 from ..shopify import ShopifyService
 from ..shopify.sync.base import ShopifyBaseImporter, ShopifyBaseExporter, ShopifyBaseDeleter
@@ -74,6 +74,7 @@ def make_pages() -> list[DummyPage]:
     return [DummyPage([1, 2], "c1", True), DummyPage([3, 4])]
 
 
+@tagged("post_install", "-at_install")
 class TestShopifySyncItems(TransactionCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
## Summary
- add post_install tag for service tests
- fix failing tests

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `pytest product_connect/services/tests -q`
