### PR TITLE
Improve service coverage

### DIFF
--- a/services/tests/test_shopify_helpers.py
+++ b/services/tests/test_shopify_helpers.py
@@ -53,6 +53,15 @@ class TestShopifyHelpers(TransactionCase):
         self.assertEqual(err.sku, "")
         self.assertEqual(err.name, "")
 
+    def test_odoo_data_error_name_only(self) -> None:
+        class Rec:
+            name = "n"
+            id = None
+            default_code = None
+
+        err = helpers.OdooDataError("msg", Rec())
+        self.assertEqual(str(err), "msg [Odoo Name n]")
+
     def test_shopify_api_error_str(self) -> None:
         class Var(BaseModel):
             sku: str | None = None
@@ -224,6 +233,9 @@ class TestShopifyHelpers(TransactionCase):
     def test_parse_shopify_id_from_gid(self) -> None:
         self.assertEqual(helpers.parse_shopify_id_from_gid("gid://shopify/product/123"), "123")
 
+    def test_parse_shopify_id_from_gid_int(self) -> None:
+        self.assertEqual(helpers.parse_shopify_id_from_gid(5), "5")
+
     def test_parse_datetime_and_format_with_naive(self) -> None:
         dt_str = "2024-05-20T07:34:56-05:00"
         parsed = helpers.parse_shopify_datetime_to_utc(dt_str)
@@ -302,6 +314,41 @@ class TestShopifyHelpers(TransactionCase):
         self.assertFalse(changed)
         self.assertEqual(rec._written, [])
         self.assertEqual(rec._fields["price"].count, 1)
+
+    def test_write_if_changed_many2one_changed(self) -> None:
+        class Base:
+            def __len__(self) -> int:
+                return 1
+
+            def __init__(self, rec_id: int) -> None:
+                self.id = rec_id
+
+        helpers.models.BaseModel = Base  # type: ignore
+
+        class Rec:
+            def __init__(self) -> None:
+                self.m2o = Base(1)
+                self._fields = {"m2o": object()}
+                self.env = object()
+                self._written: list[dict[str, Base]] = []
+
+            def __getitem__(self, name: str) -> Base:
+                return getattr(self, name)
+
+            def with_context(self, **_kw: object) -> "Rec":
+                return self
+
+            def write(self, vals: dict[str, Base]) -> None:
+                self._written.append(vals)
+                for k, v in vals.items():
+                    setattr(self, k, v)
+
+        rec = Rec()
+        new = Base(2)
+        changed = helpers.write_if_changed(cast(Any, rec), {"m2o": new})
+        self.assertTrue(changed)
+        self.assertEqual(rec.m2o.id, 2)
+        self.assertEqual(rec._written, [{"m2o": new}])
 
     def test_shopify_api_error_sku_missing(self) -> None:
         class Prod(BaseModel):

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -286,3 +286,45 @@ class TestShopifyService(TransactionCase):
             hook = client.event_hooks["response"][0]
             hook(Resp())
             fake_sleep.assert_not_called()
+
+    def test_rate_limit_hook_closed_or_no_wait(self) -> None:
+        service = self._service()
+
+        class DummyClient:
+            def __init__(self, **kw: object) -> None:
+                self.event_hooks = kw.get("event_hooks", {})
+
+            def send(self, request: Request, **_kw: object) -> Response:
+                return Response(200, request=request)
+
+        class Resp:
+            def __init__(self, data: dict, closed: bool) -> None:
+                self.headers = {"content-type": "application/json"}
+                self._json = data
+                self.is_closed = closed
+                self.read_called = False
+                self.request = Request("GET", "http://t")
+
+            def read(self) -> None:
+                self.read_called = True
+                self.is_closed = True
+
+            def json(self) -> dict:
+                return self._json
+
+            def close(self) -> None:
+                self.is_closed = True
+
+        with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
+            client = service._create_http_client("t")
+            hook = client.event_hooks["response"][0]
+            resp_closed = Resp({}, True)
+            hook(resp_closed)
+            self.assertFalse(resp_closed.read_called)
+
+            resp_ok = Resp(
+                {"extensions": {"cost": {"throttleStatus": {"currentlyAvailable": service.MIN_API_POINTS, "restoreRate": 1}}}},
+                False,
+            )
+            hook(resp_ok)
+            fake_sleep.assert_not_called()


### PR DESCRIPTION
## Summary
- extend Shopify helper tests for branch coverage
- add rate-limit regression test for Shopify service

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `pytest services/tests --odoo-database=$ODOO_DATABASE --odoo-addons-path=$ODOO_ADDONS_PATH --cov=services --cov-branch`
