### PR TITLE
Improve service coverage

### DIFF
--- a/services/tests/test_shopify_helpers.py
+++ b/services/tests/test_shopify_helpers.py
@@ -52,6 +52,16 @@ class TestShopifyHelpers(TransactionCase):
         err = helpers.OdooDataError("x")
         self.assertEqual(err.sku, "")
         self.assertEqual(err.name, "")
+        self.assertEqual(str(err), "x")
+
+    def test_odoo_data_error_name_only(self) -> None:
+        class Rec:
+            name = "n"
+            id = None
+            default_code = None
+
+        err = helpers.OdooDataError("msg", Rec())
+        self.assertEqual(str(err), "msg [Odoo Name n]")
 
     def test_shopify_api_error_str(self) -> None:
         class Var(BaseModel):
@@ -224,6 +234,9 @@ class TestShopifyHelpers(TransactionCase):
     def test_parse_shopify_id_from_gid(self) -> None:
         self.assertEqual(helpers.parse_shopify_id_from_gid("gid://shopify/product/123"), "123")
 
+    def test_parse_shopify_id_from_gid_int(self) -> None:
+        self.assertEqual(helpers.parse_shopify_id_from_gid(5), "5")
+
     def test_parse_datetime_and_format_with_naive(self) -> None:
         dt_str = "2024-05-20T07:34:56-05:00"
         parsed = helpers.parse_shopify_datetime_to_utc(dt_str)
@@ -303,6 +316,41 @@ class TestShopifyHelpers(TransactionCase):
         self.assertEqual(rec._written, [])
         self.assertEqual(rec._fields["price"].count, 1)
 
+    def test_write_if_changed_many2one_changed(self) -> None:
+        class Base:
+            def __len__(self) -> int:
+                return 1
+
+            def __init__(self, rec_id: int) -> None:
+                self.id = rec_id
+
+        helpers.models.BaseModel = Base  # type: ignore
+
+        class Rec:
+            def __init__(self) -> None:
+                self.m2o = Base(1)
+                self._fields = {"m2o": object()}
+                self.env = object()
+                self._written: list[dict[str, Base]] = []
+
+            def __getitem__(self, name: str) -> Base:
+                return getattr(self, name)
+
+            def with_context(self, **_kw: object) -> "Rec":
+                return self
+
+            def write(self, vals: dict[str, Base]) -> None:
+                self._written.append(vals)
+                for k, v in vals.items():
+                    setattr(self, k, v)
+
+        rec = Rec()
+        new = Base(2)
+        changed = helpers.write_if_changed(cast(Any, rec), {"m2o": new})
+        self.assertTrue(changed)
+        self.assertEqual(rec.m2o.id, 2)
+        self.assertEqual(rec._written, [{"m2o": new}])
+
     def test_shopify_api_error_sku_missing(self) -> None:
         class Prod(BaseModel):
             id: str
@@ -325,6 +373,17 @@ class TestShopifyHelpers(TransactionCase):
     def test_shopify_product_id_no_record(self) -> None:
         err = helpers.ShopifyApiError("msg")
         self.assertEqual(err.shopify_product_id, "")
+
+    def test_shopify_api_error_no_shopify_id(self) -> None:
+        class Prod(BaseModel):
+            id: str | None = None
+            title: str = "n"
+            variants: list = []
+
+        err = helpers.ShopifyApiError("msg", shopify_record=Prod())
+        with patch.object(helpers.OdooDataError, "__str__", lambda _exc: "msg"):
+            txt = str(err)
+            self.assertNotIn("Shopify ID", txt)
 
     def test_parse_sku_no_value_error(self) -> None:
         with self.assertRaises(helpers.ShopifyMissingSkuFieldError):

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -7,6 +7,7 @@ from odoo.tests import TransactionCase, tagged
 
 from ..shopify.service import ShopifyService
 from ..shopify import service as _service_module
+from ..shopify.helpers import ShopifyApiError
 
 
 class DummySync:
@@ -285,4 +286,137 @@ class TestShopifyService(TransactionCase):
             client = service._create_http_client("t")
             hook = client.event_hooks["response"][0]
             hook(Resp())
+            fake_sleep.assert_not_called()
+
+    def test_rate_limit_hook_closed_or_no_wait(self) -> None:
+        service = self._service()
+
+        class DummyClient:
+            def __init__(self, **kw: object) -> None:
+                self.event_hooks = kw.get("event_hooks", {})
+
+            def send(self, request: Request, **_kw: object) -> Response:
+                return Response(200, request=request)
+
+        class Resp:
+            def __init__(self, data: dict, closed: bool) -> None:
+                self.headers = {"content-type": "application/json"}
+                self._json = data
+                self.is_closed = closed
+                self.read_called = False
+                self.request = Request("GET", "http://t")
+
+            def read(self) -> None:
+                self.read_called = True
+                self.is_closed = True
+
+            def json(self) -> dict:
+                return self._json
+
+            def close(self) -> None:
+                self.is_closed = True
+
+        with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
+            client = service._create_http_client("t")
+            hook = client.event_hooks["response"][0]
+            resp_closed = Resp({}, True)
+            hook(resp_closed)
+            self.assertFalse(resp_closed.read_called)
+
+            resp_ok = Resp(
+                {"extensions": {"cost": {"throttleStatus": {"currentlyAvailable": service.MIN_API_POINTS, "restoreRate": 1}}}},
+                False,
+            )
+            hook(resp_ok)
+            fake_sleep.assert_not_called()
+
+    def test_send_with_retry_zero_attempts(self) -> None:
+        service = self._service()
+        service.MAX_RETRY_ATTEMPTS = -1
+
+        class DummyClient:
+            def __init__(self, **kw: object) -> None:
+                self.event_hooks = kw.get("event_hooks", {})
+
+            def send(self, request: Request, **_kw: object) -> Response:
+                return Response(200, request=request)
+
+        with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
+            client = service._create_http_client("t")
+            req = Request("GET", "http://t")
+            with self.assertRaises(ShopifyApiError):
+                client.send(req)
+            fake_sleep.assert_not_called()
+
+    def test_send_with_retry_delay_no_hard_throttle(self) -> None:
+        service = self._service()
+
+        class DummyClient:
+            def __init__(self, **kw: object) -> None:
+                self.event_hooks = kw.get("event_hooks", {})
+                self.send_func: Callable[[Request], Response] = lambda request: Response(
+                    200,
+                    json={"extensions": {"cost": {"throttleStatus": {"currentlyAvailable": 400, "restoreRate": 1}}}},
+                    request=request,
+                    headers={"content-type": "application/json"},
+                )
+
+            def send(self, request: Request, **_kw: object) -> Response:
+                return self.send_func(request)
+
+        resp = Response(
+            200,
+            json={"extensions": {"cost": {"throttleStatus": {"currentlyAvailable": 400, "restoreRate": 1}}}},
+            request=Request("GET", "http://t"),
+            headers={"content-type": "application/json"},
+        )
+
+        responses = [resp, resp]
+
+        def send_one(_request: Request) -> Response:
+            return responses.pop(0)
+
+        service.MAX_RETRY_ATTEMPTS = 1
+        with patch.object(_service_module, "Client", DummyClient), patch.object(
+            _service_module, "sleep"
+        ) as fake_sleep, patch.object(service, "_throttle_info", side_effect=[(False, 2), (False, None)]):
+            client = service._create_http_client("t")
+            cast(DummyClient, client).send_func = send_one  # type: ignore
+            req = Request("GET", "http://t")
+            result = client.send(req)
+            self.assertEqual(result.status_code, 200)
+            fake_sleep.assert_called_once_with(2)
+            self.assertEqual(service.sync_record.hard_throttle_count, 0)
+
+    def test_send_with_retry_invalid_json_transient(self) -> None:
+        service = self._service()
+
+        class DummyClient:
+            def __init__(self, **kw: object) -> None:
+                self.event_hooks = kw.get("event_hooks", {})
+
+                class Resp:
+                    status_code = 200
+                    headers = {"content-type": "application/json"}
+                    request = Request("GET", "http://t")
+
+                    def json(self) -> dict:
+                        raise ValueError("bad")
+
+                    def close(self) -> None:
+                        pass
+
+                self.response = Resp()
+
+            def send(self, request: Request, **_kw: object) -> Response:
+                return self.response
+
+        service.MAX_RETRY_ATTEMPTS = 0
+        with patch.object(_service_module, "Client", DummyClient), patch.object(
+            _service_module, "sleep"
+        ) as fake_sleep, patch.object(_service_module, "THROTTLE_TRANSIENT_STATUS", {200}):
+            client = service._create_http_client("t")
+            req = Request("GET", "http://t")
+            with self.assertRaises(ShopifyApiError):
+                client.send(req)
             fake_sleep.assert_not_called()


### PR DESCRIPTION
## Summary
- extend Shopify helper tests for branch coverage
- add rate-limit regression test for Shopify service
- add retries coverage tests

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `pytest services/tests --odoo-database=$ODOO_DATABASE --odoo-addons-path=$ODOO_ADDONS_PATH --cov=services --cov-branch -q`
