### PR TITLE
Fix unresolved reference warnings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ debugpy
 watchdog
 
 types-Pillow
-types-python-dateutil
 types-requests
 types-geoip2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ simple_zpl2 @ git+https://github.com/sacherjj/simple_zpl2@master
 pillow
 qrcode
 requests
-python-dateutil
 pydantic-settings
 
 httpx[http2]

--- a/services/shopify/helpers.py
+++ b/services/shopify/helpers.py
@@ -4,7 +4,6 @@ from datetime import datetime, UTC
 from enum import StrEnum
 from typing import TypeVar, Self, Union, Any
 
-from dateutil.parser import parse
 from pydantic import BaseModel
 
 from odoo import models
@@ -243,7 +242,7 @@ def parse_shopify_datetime_to_utc(value: datetime | str) -> datetime:
     if isinstance(value, datetime):
         dt = value
     else:
-        dt = parse(value)
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return dt.astimezone(UTC).replace(tzinfo=None)

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -20,6 +20,7 @@ class _BaseDummyClient:
     def __init__(self, **kw: object) -> None:
         self.event_hooks = kw.get("event_hooks", {})
         self.send_calls: list[Request] = []
+        self.response = Response(200, request=Request("GET", "http://t"))
 
     def send(self, request: Request, **_kw: object) -> Response:
         self.send_calls.append(request)
@@ -216,7 +217,7 @@ class TestShopifyService(TransactionCase):
 
         with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
             service.MAX_RETRY_ATTEMPTS = 1
-            client = service._create_http_client("t")
+            client = cast(DummyClient, service._create_http_client("t"))
             req = Request("GET", "http://t")
             with self.assertRaises(Exception):
                 client.send(req)
@@ -236,7 +237,7 @@ class TestShopifyService(TransactionCase):
                 )
 
         with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
-            client = service._create_http_client("t")
+            client = cast(DummyClient, service._create_http_client("t"))
             req = Request("GET", "http://t")
             result = client.send(req)
             self.assertIs(result, client.response)
@@ -264,7 +265,7 @@ class TestShopifyService(TransactionCase):
                 self.response = Resp()
 
         with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
-            client = service._create_http_client("t")
+            client = cast(DummyClient, service._create_http_client("t"))
             req = Request("GET", "http://t")
             result = client.send(req)
             self.assertIs(result, client.response)


### PR DESCRIPTION
## Summary
- fix unresolved attributes in DummyClient tests
- simplify Shopify date parsing
- remove dateutil dependency

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `/odoo/odoo-bin -d $ODOO_DATABASE -i base,product_connect --addons-path=$ODOO_ADDONS_PATH --stop-after-init --test-enable --log-level=warn` *(fails: ModuleNotFoundError: No module named 'babel')*