### PR TITLE
Refactor tests

### DIFF
--- a/services/tests/test_shopify_helpers.py
+++ b/services/tests/test_shopify_helpers.py
@@ -11,6 +11,70 @@ from ..shopify import helpers
 
 @tagged("post_install", "-at_install")
 class TestShopifyHelpers(TransactionCase):
+
+    def _make_rec(self, include_price: bool) -> tuple[type, object, object | None]:
+        class Base:
+            def __len__(self) -> int:
+                return 1
+
+            def __init__(self, rec_id: int) -> None:
+                self.id = rec_id
+
+        helpers.models.BaseModel = Base  # type: ignore
+
+        if include_price:
+
+            class FloatField:
+                def __init__(self) -> None:
+                    self.count = 0
+
+                def digits(self, _env: object) -> tuple[int, int]:
+                    self.count += 1
+                    return 16, 2
+
+            field = FloatField()
+
+            class Rec:
+                def __init__(self) -> None:
+                    self.m2o = Base(1)
+                    self.price = 1.0
+                    self.env = object()
+                    self._fields = {"m2o": object(), "price": field}
+                    self._written: list[dict[str, object]] = []
+
+                def __getitem__(self, name: str) -> object:
+                    return getattr(self, name)
+
+                def with_context(self, **_kw: object) -> "Rec":
+                    return self
+
+                def write(self, vals: dict[str, object]) -> None:
+                    self._written.append(vals)
+                    for k, v in vals.items():
+                        setattr(self, k, v)
+
+            return Base, Rec(), field
+
+        class RecNoPrice:
+            def __init__(self) -> None:
+                self.m2o = Base(1)
+                self._fields = {"m2o": object()}
+                self.env = object()
+                self._written: list[dict[str, Base]] = []
+
+            def __getitem__(self, name: str) -> Base:
+                return getattr(self, name)
+
+            def with_context(self, **_kw: object) -> "Rec":
+                return self
+
+            def write(self, vals: dict[str, Base]) -> None:
+                self._written.append(vals)
+                for k, v in vals.items():
+                    setattr(self, k, v)
+
+        return Base, RecNoPrice(), None
+
     def test_normalise_values(self) -> None:
         cases: List[Tuple[str, Callable[[str], str], str]] = [
             (" TeSt  ", helpers.normalize_str, "test"),
@@ -273,78 +337,16 @@ class TestShopifyHelpers(TransactionCase):
         self.assertEqual(helpers.determine_latest_odoo_product_modification_time(Prod()), helpers.DEFAULT_DATETIME)
 
     def test_write_if_changed_single_record_and_callable_digits(self) -> None:
-        class Base:
-            def __len__(self) -> int:
-                return 1
-
-            def __init__(self, rec_id: int) -> None:
-                self.id = rec_id
-
-        helpers.models.BaseModel = Base  # type: ignore
-
-        class FloatField:
-            def __init__(self) -> None:
-                self.count = 0
-
-            def digits(self, _env: object) -> tuple[int, int]:
-                self.count += 1
-                return 16, 2
-
-        class Rec:
-            def __init__(self) -> None:
-                self.m2o = Base(1)
-                self.price = 1.0
-                self.env = object()
-                self._fields = {"m2o": object(), "price": FloatField()}
-                self._written: list[dict[str, object]] = []
-
-            def __getitem__(self, name: str) -> object:
-                return getattr(self, name)
-
-            def with_context(self, **_kw: object) -> "Rec":
-                return self
-
-            def write(self, vals: dict[str, object]) -> None:
-                self._written.append(vals)
-                for k, v in vals.items():
-                    setattr(self, k, v)
-
-        rec = Rec()
+        Base, rec, field = self._make_rec(True)
         new_vals = {"m2o": Base(1), "price": 1.0}
         changed = helpers.write_if_changed(cast(Any, rec), new_vals)
         self.assertFalse(changed)
         self.assertEqual(rec._written, [])
-        self.assertEqual(rec._fields["price"].count, 1)
+        assert field is not None
+        self.assertEqual(field.count, 1)
 
     def test_write_if_changed_many2one_changed(self) -> None:
-        class Base:
-            def __len__(self) -> int:
-                return 1
-
-            def __init__(self, rec_id: int) -> None:
-                self.id = rec_id
-
-        helpers.models.BaseModel = Base  # type: ignore
-
-        class Rec:
-            def __init__(self) -> None:
-                self.m2o = Base(1)
-                self._fields = {"m2o": object()}
-                self.env = object()
-                self._written: list[dict[str, Base]] = []
-
-            def __getitem__(self, name: str) -> Base:
-                return getattr(self, name)
-
-            def with_context(self, **_kw: object) -> "Rec":
-                return self
-
-            def write(self, vals: dict[str, Base]) -> None:
-                self._written.append(vals)
-                for k, v in vals.items():
-                    setattr(self, k, v)
-
-        rec = Rec()
+        Base, rec, _field = self._make_rec(False)
         new = Base(2)
         changed = helpers.write_if_changed(cast(Any, rec), {"m2o": new})
         self.assertTrue(changed)

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -1,5 +1,6 @@
-from typing import Callable, cast
-from unittest.mock import patch
+from typing import Callable, Iterator, Tuple, cast
+from unittest.mock import patch, MagicMock
+from contextlib import contextmanager
 
 from httpx import Request, Response
 from odoo.tests import TransactionCase, tagged
@@ -31,6 +32,14 @@ class _BaseDummyClient:
 class TestShopifyService(TransactionCase):
     def _service(self) -> ShopifyService:
         return ShopifyService(self.env, DummySync())
+
+    @contextmanager
+    def _client(
+        self, service: ShopifyService, client_cls: type[_BaseDummyClient]
+    ) -> Iterator[Tuple[_BaseDummyClient, MagicMock]]:
+        with patch.object(_service_module, "Client", client_cls), patch.object(_service_module, "sleep") as fake_sleep:
+            client = cast(_BaseDummyClient, service._create_http_client("t"))
+            yield client, fake_sleep
 
     def test_compute_throttle_delay_none(self) -> None:
         service = self._service()
@@ -215,9 +224,8 @@ class TestShopifyService(TransactionCase):
                 self.send_calls.append(request)
                 return self.send_func(request)
 
-        with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
+        with self._client(service, DummyClient) as (client, fake_sleep):
             service.MAX_RETRY_ATTEMPTS = 1
-            client = cast(DummyClient, service._create_http_client("t"))
             req = Request("GET", "http://t")
             with self.assertRaises(Exception):
                 client.send(req)
@@ -236,8 +244,7 @@ class TestShopifyService(TransactionCase):
                     request=Request("GET", "http://t"),
                 )
 
-        with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
-            client = cast(DummyClient, service._create_http_client("t"))
+        with self._client(service, DummyClient) as (client, fake_sleep):
             req = Request("GET", "http://t")
             result = client.send(req)
             self.assertIs(result, client.response)
@@ -264,8 +271,7 @@ class TestShopifyService(TransactionCase):
 
                 self.response = Resp()
 
-        with patch.object(_service_module, "Client", DummyClient), patch.object(_service_module, "sleep") as fake_sleep:
-            client = cast(DummyClient, service._create_http_client("t"))
+        with self._client(service, DummyClient) as (client, fake_sleep):
             req = Request("GET", "http://t")
             result = client.send(req)
             self.assertIs(result, client.response)


### PR DESCRIPTION
## Summary
- create helper `_make_rec` to avoid test duplicates
- add context manager for patched client in Shopify service tests

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
- `odoo-bin -d $ODOO_DATABASE -i product_connect --addons-path=$ODOO_ADDONS_PATH --stop-after-init --test-enable --log-level=warn --test-tags /product_connect` *(fails: Tour motor_frontend_tour → Step .o_form_button_edit)*