### PR TITLE
Fix Shopify client init

### DIFF
--- a/services/shopify/service.py
+++ b/services/shopify/service.py
@@ -31,9 +31,9 @@ class ShopifyService:
 
         return self._client
 
-    def get_first_location_gid(self) -> str:
-        client = self.client
-        shopify_response = client.get_locations()
+    def get_first_location_gid(self, client: ShopifyClient | None = None) -> str:
+        shopify = client or self.client
+        shopify_response = shopify.get_locations()
         locations = shopify_response.nodes
         if not locations:
             raise ShopifyApiError("No locations found in the Shopify store.")
@@ -57,8 +57,9 @@ class ShopifyService:
         endpoint = f"https://{shop_url_key}.myshopify.com/admin/api/{api_version}/graphql.json"
         http_client = self._create_http_client(api_token)
         client = ShopifyClient(http_client=http_client, url=endpoint)
+        first_location_gid = self.get_first_location_gid(client)
         self._client = client
-        self.first_location_gid = self.get_first_location_gid()
+        self.first_location_gid = first_location_gid
         return client
 
     def _create_http_client(self, api_token: str) -> Client:

--- a/services/tests/test_shopify_service.py
+++ b/services/tests/test_shopify_service.py
@@ -148,6 +148,17 @@ class TestShopifyService(TransactionCase):
         with self.assertRaises(Exception):
             service._create_client()
 
+    def test_create_client_resets_on_location_error(self) -> None:
+        config = self.env["ir.config_parameter"].sudo()
+        config.set_param("shopify.shop_url_key", "shop")
+        config.set_param("shopify.api_token", "token")
+        service = self._service()
+
+        with patch.object(service, "get_first_location_gid", side_effect=ShopifyApiError("boom")):
+            with self.assertRaises(ShopifyApiError):
+                service._create_client()
+        self.assertIsNone(service._client)
+
     def test_client_property_creates_client(self) -> None:
         service = self._service()
 


### PR DESCRIPTION
## Summary
- handle location lookup failures when creating Shopify client
- test for resetting client on location errors

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=product_connect/mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' product_connect`
- ❌ `/odoo/odoo-bin -d $ODOO_DATABASE -u product_connect --addons-path=$ODOO_ADDONS_PATH --stop-after-init --test-enable --log-level=info` (failed: `/odoo/odoo-bin: No such file or directory`)
