### PR TITLE
Fix test discovery for Odoo

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,3 +17,6 @@ if addons_path and addons_path != current_path:
 
 if __name__.startswith("odoo.addons."):
     from . import mixins, controllers, models, wizards
+
+if odoo_config.get("test_enable"):
+    from . import tests


### PR DESCRIPTION
## Summary
- load tests when `test_enable` flag is set in __init__

## Testing
- `black --line-length 130 --extend-exclude 'services/shopify/gql|graphql/schema' .`
- `mypy --config-file=mypy.ini --follow-imports=silent --exclude '(\.pyi$|services/shopify/gql/|graphql/schema/)' .`
